### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Paketo Git Buildpack
-The Paketo Git Buildpack is a Cloud Native Buildpack that retrieves `git` metadata and performs `git` operations.
+# Paketo Buildpack for Git
+The Paketo Buildpack for Git is a Cloud Native Buildpack that retrieves `git` metadata and performs `git` operations.
 
 ## Behavior
 This buildpack uses the `git` dependency off of the stack that it is running on top of. The Git buildpack will only participate if there is a valid `.git` directory in the application source directory or if there a `git-credentials` service bindings present.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/git"
   id = "paketo-buildpacks/git"
-  name = "Paketo Git Buildpack"
+  name = "Paketo Buildpack for Git"
 
 [metadata]
   include-files = ["bin/run", "bin/build", "bin/detect", "buildpack.toml"]

--- a/integration/credential_configuration_test.go
+++ b/integration/credential_configuration_test.go
@@ -73,7 +73,7 @@ func testCredentialConfiguration(t *testing.T, context spec.G, it spec.S) {
 				"  Configuring credentials",
 				"  Added 1 custom git credential manager(s) to the git config",
 				"",
-				"Paketo Credential Fill Buildpack",
+				"Paketo Buildpack for Credential Fill",
 				"protocol=https",
 				"host=example.com",
 				"username=username",

--- a/integration/testdata/credential_fill_buildpack/bin/build
+++ b/integration/testdata/credential_fill_buildpack/bin/build
@@ -5,7 +5,7 @@ set -u
 set -o pipefail
 
 function main() {
-  echo "Paketo Credential Fill Buildpack"
+  echo "Paketo Buildpack for Credential Fill"
   echo url=https://example.com | git credential fill
 }
 

--- a/integration/testdata/credential_fill_buildpack/buildpack.toml
+++ b/integration/testdata/credential_fill_buildpack/buildpack.toml
@@ -2,7 +2,7 @@ api = "0.7"
 
 [buildpack]
   id = "paketo-buildpacks/git/credential_fill"
-  name = "Paketo Credential Fill Buildpack"
+  name = "Paketo Buildpack for Credential Fill "
   version = "0.0.1"
 
 [[stacks]]


### PR DESCRIPTION
Renames 'Paketo Git Buildpack' to 'Paketo Buildpack for Git'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
